### PR TITLE
Добавить www-data в группу installer_user для доступа nginx к статическим файлам

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/install_scripts/issues/5
-Your prepared branch: issue-5-024085c008bb
-Your prepared working directory: /tmp/gh-issue-solver-1766613550456
-Your forked repository: konard/andchir-install_scripts
-Original repository (upstream): andchir/install_scripts
-
-Proceed.


### PR DESCRIPTION
## Summary

Добавлено добавление пользователя `www-data` в группу `installer_user` в скрипте `scripts/various-useful-api-django.sh`.

- Добавлен вызов `usermod -aG "$INSTALLER_USER" www-data` в функцию `add_user_to_www_data()`
- Это позволяет nginx (который работает как `www-data`) получить доступ к статическим файлам, принадлежащим `installer_user`

## Changes

Изменена функция `add_user_to_www_data()` - добавлены строки:
```bash
print_step "Adding www-data to $INSTALLER_USER group..."
usermod -aG "$INSTALLER_USER" www-data
print_success "www-data added to $INSTALLER_USER group (allows nginx access to static files)"
```

## Test plan

- [ ] Запустить скрипт на тестовом сервере Ubuntu 24.04
- [ ] Проверить, что пользователь `www-data` добавлен в группу `installer_user`: `groups www-data`
- [ ] Проверить, что nginx имеет доступ к статическим файлам

Fixes andchir/install_scripts#5

🤖 Generated with [Claude Code](https://claude.com/claude-code)