### PR TITLE
api - добавить роут /api/script/<script_name>

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -119,7 +119,7 @@ def get_script(script_name):
             return jsonify({
                 'success': False,
                 'error': 'Data file not found',
-                'script': None
+                'result': None
             }), 404
 
         # Load scripts from the data file
@@ -131,33 +131,33 @@ def get_script(script_name):
             if script.get('script_name') == script_name:
                 return jsonify({
                     'success': True,
-                    'script': script
+                    'result': script
                 })
 
         # Script not found
         return jsonify({
             'success': False,
             'error': f'Script with script_name "{script_name}" not found',
-            'script': None
+            'result': None
         }), 404
 
     except json.JSONDecodeError as e:
         return jsonify({
             'success': False,
             'error': f'Invalid JSON format in data file: {str(e)}',
-            'script': None
+            'result': None
         }), 500
     except PermissionError:
         return jsonify({
             'success': False,
             'error': 'Permission denied accessing data file',
-            'script': None
+            'result': None
         }), 403
     except Exception as e:
         return jsonify({
             'success': False,
             'error': str(e),
-            'script': None
+            'result': None
         }), 500
 
 

--- a/examples/test_flask_api.py
+++ b/examples/test_flask_api.py
@@ -75,8 +75,8 @@ class TestFlaskAPI(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertTrue(data['success'])
-        self.assertIn('script', data)
-        self.assertEqual(data['script']['script_name'], 'various-useful-api-django')
+        self.assertIn('result', data)
+        self.assertEqual(data['result']['script_name'], 'various-useful-api-django')
 
     def test_get_script_not_found(self):
         """Test that /api/script/<script_name> returns 404 for non-existent script."""
@@ -85,7 +85,7 @@ class TestFlaskAPI(unittest.TestCase):
         data = response.get_json()
         self.assertFalse(data['success'])
         self.assertIn('error', data)
-        self.assertIsNone(data['script'])
+        self.assertIsNone(data['result'])
 
     def test_get_script_with_lang_param(self):
         """Test the /api/script/<script_name> endpoint with lang parameter."""
@@ -94,9 +94,9 @@ class TestFlaskAPI(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         data = response.get_json()
         self.assertTrue(data['success'])
-        self.assertIn('script', data)
+        self.assertIn('result', data)
         # English description should contain "A collection of useful APIs"
-        self.assertIn('A collection of useful APIs', data['script']['description'])
+        self.assertIn('A collection of useful APIs', data['result']['description'])
 
         # Test with Russian (default)
         response = self.client.get('/api/script/various-useful-api-django?lang=ru')
@@ -104,7 +104,7 @@ class TestFlaskAPI(unittest.TestCase):
         data = response.get_json()
         self.assertTrue(data['success'])
         # Russian description should contain "Набор полезных API"
-        self.assertIn('Набор полезных API', data['script']['description'])
+        self.assertIn('Набор полезных API', data['result']['description'])
 
     def test_get_script_all_scripts(self):
         """Test that all scripts in data file can be retrieved individually."""
@@ -120,7 +120,7 @@ class TestFlaskAPI(unittest.TestCase):
             self.assertEqual(response.status_code, 200, f"Failed to get script: {script_name}")
             script_data = response.get_json()
             self.assertTrue(script_data['success'])
-            self.assertEqual(script_data['script']['script_name'], script_name)
+            self.assertEqual(script_data['result']['script_name'], script_name)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- Добавлен новый endpoint `/api/script/<script_name>` для получения информации об одном скрипте
- Поддержка параметра `lang` для выбора языка (аналогично `/api/scripts_list`)
- Возвращает информацию из JSON файла для одного скрипта по полю `script_name`
- Добавлены тесты для нового endpoint

## Usage Examples
```bash
# Получение информации о скрипте (по умолчанию на русском)
curl http://localhost:5000/api/script/various-useful-api-django

# Получение информации на английском
curl http://localhost:5000/api/script/various-useful-api-django?lang=en

# Получение информации о несуществующем скрипте (вернёт 404)
curl http://localhost:5000/api/script/non-existent-script
```

## Response Format
### Успешный ответ
```json
{
  "success": true,
  "result": {
    "name": "andchir/various-useful-api-django",
    "script_name": "various-useful-api-django",
    "description": "Набор полезных API с использованием Django",
    "info": "Необходимый параметр: доменное имя"
  }
}
```

### Скрипт не найден (404)
```json
{
  "success": false,
  "error": "Script with script_name \"non-existent-script\" not found",
  "result": null
}
```

## Test plan
- [x] Тест получения информации о существующем скрипте
- [x] Тест получения информации с параметром `lang=en`
- [x] Тест получения информации с параметром `lang=ru`
- [x] Тест ошибки 404 для несуществующего скрипта
- [x] Тест получения всех скриптов по одному
- [ ] Ручное тестирование

Fixes andchir/install_scripts#27

🤖 Generated with [Claude Code](https://claude.com/claude-code)