### PR TITLE
Исправить скрипт установки WordPress: добавить обход проверки пароля root MySQL

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/andchir/install_scripts/issues/96
-Your prepared branch: issue-96-a91c193a53f4
-Your prepared working directory: /tmp/gh-issue-solver-1766785503103
-Your forked repository: konard/andchir-install_scripts
-Original repository (upstream): andchir/install_scripts
-
-Proceed.


### PR DESCRIPTION
## Summary

Исправляет скрипт установки WordPress, чтобы он работал на серверах, где MySQL уже установлен и root пользователь имеет включенную аутентификацию по паролю.

Fixes andchir/install_scripts#96

## Проблема

Если сервер базы данных уже установлен и root пользователь MySQL имеет аутентификацию по паролю, скрипт `wordpress.sh` не может создать базу данных для WordPress, так как не имеет доступа.

## Решение

Скрипт теперь:
1. Проверяет, можно ли подключиться к MySQL как root без пароля
2. Если нет - временно отключает использование пароля root:
   - Останавливает MySQL
   - Запускает MySQL в режиме восстановления (`--skip-grant-tables`)
   - Получает текущий плагин аутентификации root пользователя
   - Переключает root на плагин `auth_socket` (позволяет подключаться без пароля при запуске от root)
   - Перезапускает MySQL в нормальном режиме
3. Создает базу данных и пользователя для WordPress
4. Восстанавливает оригинальный плагин аутентификации root пользователя

Это позволяет скрипту работать на серверах, где MySQL был ранее установлен, без изменения пароля root.

## Changes Made

- `scripts/wordpress.sh`: Добавлена логика временного отключения аутентификации по паролю root в функции `configure_mysql()`

## Test Plan
- [x] Скрипт проходит проверку синтаксиса `bash -n`
- [ ] Ручное тестирование на сервере с уже установленным MySQL и включенным паролем root
- [ ] Ручное тестирование на свежем сервере (обратная совместимость)

🤖 Generated with [Claude Code](https://claude.com/claude-code)