### PR TITLE
Исправить конфликт портов Xray с Nginx в xray-3x-ui.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,15 +5,3 @@ Your forked repository: konard/andchir-install_scripts
 Original repository (upstream): andchir/install_scripts
 
 Proceed.
-
----
-
-Issue to solve: https://github.com/andchir/install_scripts/issues/111
-Your prepared branch: issue-111-4470dccd3551
-Your prepared working directory: /tmp/gh-issue-solver-1766845778810
-Your forked repository: konard/andchir-install_scripts
-Original repository (upstream): andchir/install_scripts
-
-Proceed.
-
-Run timestamp: 2025-12-27T14:29:43.072Z


### PR DESCRIPTION
## Описание

Исправляет проблему конфликта портов между Xray и Nginx в скрипте установки 3x-ui.

### Проблема

При установке скрипт `xray-3x-ui.sh` загружал и устанавливал внешний сервис Xray из [XTLS/Xray-install](https://github.com/XTLS/Xray-install). Этот внешний сервис мог конфликтовать с Nginx, так как оба пытались использовать порты 80/443.

Ошибка из отчёта:
```
╔══════════════════════════════════════════════════════════════════════════════╗
║  Installing Xray Service
╚══════════════════════════════════════════════════════════════════════════════╝

➜ Installing Xray for the first time...
➜ Downloading Xray installer...
✔ Xray installer downloaded
➜ Running Xray installer...
✖ Xray installation failed
```

### Решение

**3x-ui уже включает собственный встроенный Xray** в директории `/usr/local/x-ui/bin/`. Панель 3x-ui самостоятельно управляет этим встроенным Xray, поэтому внешний сервис Xray не нужен.

### Изменения

1. **Удалена функция `install_xray()`** - заменена на `check_xray_bundled()`
2. **Новая функция** останавливает и отключает внешний сервис `xray`, если он существует, для предотвращения конфликтов портов
3. **Обновлены комментарии и сообщения** для отражения того, что 3x-ui использует встроенный Xray
4. **Обновлён баннер** - теперь отображает "3x-ui panel with bundled Xray"

### Тестирование

- [x] Синтаксис bash-скрипта проверен (`bash -n`)
- [x] Изменения соответствуют официальному установщику 3x-ui

Fixes andchir/install_scripts#111

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)