### PR TITLE
Обновить скрипт libretranslate.sh для работы только на CPU

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,3 @@ Your forked repository: konard/andchir-install_scripts
 Original repository (upstream): andchir/install_scripts
 
 Proceed.
-
----
-
-Issue to solve: https://github.com/andchir/install_scripts/issues/157
-Your prepared branch: issue-157-fe904b4654ca
-Your prepared working directory: /tmp/gh-issue-solver-1767028259039
-Your forked repository: konard/andchir-install_scripts
-Original repository (upstream): andchir/install_scripts
-
-Proceed.
-
-
-Run timestamp: 2025-12-29T17:11:04.882Z


### PR DESCRIPTION
## Summary

Обновлён скрипт libretranslate.sh согласно запросу в issue #157:
- При установке отключено использование GPU (nvidia), используется только CPU
- Не устанавливаются пакеты для GPU

### Изменения

- **Установка PyTorch CPU-only версии** перед LibreTranslate для исключения зависимостей NVIDIA CUDA
- **Добавлена переменная окружения `ARGOS_DEVICE_TYPE=cpu`** в systemd сервис для явного указания режима работы на CPU
- **Обновлён комментарий в заголовке скрипта** для отражения конфигурации только для CPU

### Технические детали

PyTorch устанавливается с использованием CPU-only индекса:
```bash
pip install torch --index-url https://download.pytorch.org/whl/cpu
```

Это позволяет избежать установки больших библиотек NVIDIA CUDA (~2GB+).

В systemd сервисе добавлена переменная окружения:
```ini
Environment="ARGOS_DEVICE_TYPE=cpu"
```

### Ссылки
- [LibreTranslate Community: Using Argos Translate without Nvidia dependencies](https://community.libretranslate.com/t/using-argos-translate-without-nvidia-dependencies/1061)
- [Argos Translate Settings](https://github.com/argosopentech/argos-translate/blob/master/argostranslate/settings.py)

Fixes andchir/install_scripts#157

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)